### PR TITLE
Remove local-only label from admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,7 +62,6 @@
 <div class="app">
   <div class="topbar">
     <h1>Map Admin • Marker Dashboard</h1>
-    <span class="pill">Local-only • no backend</span>
   </div>
 
   <div class="main">


### PR DESCRIPTION
## Summary
- Remove local-only disclaimer from the admin dashboard header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a85602cdc832eabf05c5156a2030d