### PR TITLE
Fix custom map loading with correct bounds and script order

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     integrity="sha256-sA+e2tuEeMq4Jg3oH2CBjDEZoJBqNNP5ue1c8qYnY+o="
     crossorigin=""
   />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
   <div id="map"></div>
@@ -21,7 +21,7 @@
     integrity="sha256-Vn0vIvZ4bqkG3wQ3VbQWoIyN4KxDtci5sRNXuNX3F0o="
     crossorigin="">
   </script>
-  <script src="markers.js"></script>
-  <script src="map.js"></script>
+  <script src="./markers.js" defer></script>
+  <script src="./map.js" defer></script>
 </body>
 </html>

--- a/map.js
+++ b/map.js
@@ -4,26 +4,30 @@ const map = L.map('map', {
   maxZoom: 4,
 });
 
-const imageUrl = 'custom_maps/map.png';
+const imageUrl = './custom_maps/map.png';
 const img = new Image();
 img.src = imageUrl;
 img.onload = () => {
-  const bounds = [[0, 0], [img.height, img.width]];
+  const bounds = [[img.height, 0], [0, img.width]];
   L.imageOverlay(imageUrl, bounds).addTo(map);
   map.fitBounds(bounds);
+
+  (markersData || []).forEach((m) => {
+    L.marker([m.lat, m.lng], { icon: getIcon(m.icon) })
+      .addTo(map)
+      .bindPopup(`<h3>${m.name}</h3><p>${m.description}</p>`);
+  });
+};
+
+img.onerror = (e) => {
+  console.error('Failed to load map image', e);
 };
 
 function getIcon(name = 'default.webp') {
   return L.icon({
-    iconUrl: `custom_icons/${name}`,
+    iconUrl: `./custom_icons/${name}`,
     iconSize: [32, 32],
     iconAnchor: [16, 16],
     popupAnchor: [0, -16],
   });
 }
-
-(markersData || []).forEach((m) => {
-  L.marker([m.lat, m.lng], { icon: getIcon(m.icon) })
-    .addTo(map)
-    .bindPopup(`<h3>${m.name}</h3><p>${m.description}</p>`);
-});

--- a/markers.js
+++ b/markers.js
@@ -1,16 +1,23 @@
 const markersData = [
   {
-    name: "Central Park",
-    lat: 40.7829,
-    lng: -73.9654,
-    description: "A large public park in New York City.",
+    name: "Center",
+    lat: 377,
+    lng: 773,
+    description: "Center of the custom map.",
     icon: "default.webp",
   },
   {
-    name: "Eiffel Tower",
-    lat: 48.8584,
-    lng: 2.2945,
-    description: "Iconic Parisian landmark.",
+    name: "Top Left",
+    lat: 50,
+    lng: 50,
+    description: "Near the top-left corner.",
     icon: "default.webp",
-  }
+  },
+  {
+    name: "Bottom Right",
+    lat: 700,
+    lng: 1500,
+    description: "Near the bottom-right corner.",
+    icon: "default.webp",
+  },
 ];


### PR DESCRIPTION
## Summary
- load assets and scripts with relative paths and deferred execution
- compute bounds correctly for custom image map and add error handling
- update marker coordinates for the custom map image

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/map/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a98012a10832e87024b240758fa53