### PR TITLE
Handle missing markers so map displays base image

### DIFF
--- a/map.js
+++ b/map.js
@@ -12,7 +12,8 @@ img.onload = () => {
   L.imageOverlay(imageUrl, bounds).addTo(map);
   map.fitBounds(bounds);
 
-  (markersData || []).forEach((m) => {
+  const markers = (typeof window !== 'undefined' && window.markersData) || [];
+  markers.forEach((m) => {
     L.marker([m.lat, m.lng], { icon: getIcon(m.icon) })
       .addTo(map)
       .bindPopup(`<h3>${m.name}</h3><p>${m.description}</p>`);


### PR DESCRIPTION
## Summary
- Avoid ReferenceError when marker data isn't loaded by checking `window.markersData`
- Ensure map renders even if no markers are present

## Testing
- `node --check map.js`

------
https://chatgpt.com/codex/tasks/task_e_689aa69b1118832e9602f5b265030937