### PR TITLE
feat: allow uploading custom map image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a small Leaflet-based map web site and a modern admin p
 
 ## Pages
 
-- `index.html` – interactive map displaying markers with custom icons and popups.
+- `index.html` – interactive map displaying markers with custom icons and popups. You can upload a map image directly in the browser to preview different custom maps.
 - `admin.html` – dashboard for adding, importing, and exporting markers. Data is stored in `localStorage` and can be exported as JSON or a JS array for updating `markers.js`.
 
 ## Development

--- a/index.html
+++ b/index.html
@@ -14,7 +14,12 @@
 </head>
 <body>
   <div id="map"></div>
-  <a id="admin-link" href="admin.html">Admin Panel</a>
+  <div id="controls">
+    <a id="admin-link" href="admin.html">Admin Panel</a>
+    <label>Upload Map Image:
+      <input type="file" id="mapUpload" accept="image/*" />
+    </label>
+  </div>
 
   <script
     src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"

--- a/map.js
+++ b/map.js
@@ -4,25 +4,50 @@ const map = L.map('map', {
   maxZoom: 4,
 });
 
-const imageUrl = './custom_maps/map.png';
-const img = new Image();
-img.src = imageUrl;
-img.onload = () => {
-  const bounds = [[img.height, 0], [0, img.width]];
-  L.imageOverlay(imageUrl, bounds).addTo(map);
-  map.fitBounds(bounds);
+const markers = (typeof window !== 'undefined' && window.markersData) || [];
+let imageOverlay;
+let markerLayers = [];
 
-  const markers = (typeof window !== 'undefined' && window.markersData) || [];
+function addMarkers() {
+  markerLayers.forEach((m) => map.removeLayer(m));
+  markerLayers = [];
   markers.forEach((m) => {
-    L.marker([m.lat, m.lng], { icon: getIcon(m.icon) })
+    const layer = L.marker([m.lat, m.lng], { icon: getIcon(m.icon) })
       .addTo(map)
       .bindPopup(`<h3>${m.name}</h3><p>${m.description}</p>`);
+    markerLayers.push(layer);
   });
-};
+}
 
-img.onerror = (e) => {
-  console.error('Failed to load map image', e);
-};
+function loadMap(src) {
+  const img = new Image();
+  img.onload = () => {
+    const bounds = [[img.height, 0], [0, img.width]];
+    if (imageOverlay) {
+      map.removeLayer(imageOverlay);
+    }
+    imageOverlay = L.imageOverlay(src, bounds).addTo(map);
+    map.fitBounds(bounds);
+    addMarkers();
+  };
+  img.onerror = (e) => {
+    console.error('Failed to load map image', e);
+  };
+  img.src = src;
+}
+
+loadMap('./custom_maps/map.png');
+
+const fileInput = document.getElementById('mapUpload');
+if (fileInput) {
+  fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => loadMap(ev.target.result);
+    reader.readAsDataURL(file);
+  });
+}
 
 function getIcon(name = 'default.webp') {
   return L.icon({
@@ -32,3 +57,4 @@ function getIcon(name = 'default.webp') {
     popupAnchor: [0, -16],
   });
 }
+

--- a/style.css
+++ b/style.css
@@ -10,7 +10,25 @@ html, body {
 }
 
 #controls {
-  padding: 1rem;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 10px;
+  border-radius: 8px;
+  z-index: 1000;
+}
+
+#controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  color: #000;
+}
+
+#admin-link {
+  display: block;
+  margin-bottom: 8px;
 }
 
 #controls form {


### PR DESCRIPTION
## Summary
- add upload control to map page
- overlay uploaded map images with Leaflet
- document custom map upload support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aabef6e04832eb64cfb7ade7e9cdb