### PR TITLE
Add marker categories and layer control

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project is a minimal example of using [Leaflet](https://leafletjs.com/) wit
 Markers are loaded from `markers.json` on the main page and a simple admin page lets you manage
 markers in `localStorage` and download them as JSON.
 
+Markers now include a `type` field (e.g. `city`, `town`, `poi`) that controls the marker icon and
+lets visitors toggle categories via the layer control.
+
 ## Pages
 - `index.html` – shows the map and markers.
 - `admin.html` – add or remove markers and export them.

--- a/admin.html
+++ b/admin.html
@@ -18,11 +18,16 @@
   <input id="lat" type="number" step="any" placeholder="Latitude" required />
   <input id="lng" type="number" step="any" placeholder="Longitude" required />
   <textarea id="desc" placeholder="Description"></textarea>
+  <select id="type">
+    <option value="city">City</option>
+    <option value="town">Town</option>
+    <option value="poi">POI</option>
+  </select>
   <button type="submit">Add</button>
 </form>
 <button id="download">Download JSON</button>
 <table id="list">
-  <thead><tr><th>Title</th><th>Lat</th><th>Lng</th><th></th></tr></thead>
+  <thead><tr><th>Title</th><th>Lat</th><th>Lng</th><th>Type</th><th></th></tr></thead>
   <tbody></tbody>
 </table>
 <script>
@@ -33,7 +38,7 @@ function render(){
   tbody.innerHTML='';
   markers.forEach((m,i)=>{
     const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${m.title}</td><td>${m.lat}</td><td>${m.lng}</td><td><button data-i="${i}">Delete</button></td>`;
+    tr.innerHTML=`<td>${m.title}</td><td>${m.lat}</td><td>${m.lng}</td><td>${m.type}</td><td><button data-i="${i}">Delete</button></td>`;
     tbody.appendChild(tr);
   });
 }
@@ -41,7 +46,7 @@ render();
 
 document.getElementById('markerForm').addEventListener('submit',e=>{
   e.preventDefault();
-  markers.push({title:title.value.trim(),lat:Number(lat.value),lng:Number(lng.value),description:desc.value.trim()});
+  markers.push({title:title.value.trim(),lat:Number(lat.value),lng:Number(lng.value),description:desc.value.trim(),type:type.value});
   localStorage.setItem(storeKey,JSON.stringify(markers));
   render();
   e.target.reset();

--- a/markers.json
+++ b/markers.json
@@ -3,12 +3,28 @@
     "title": "San Francisco",
     "lat": 37.7749,
     "lng": -122.4194,
-    "description": "City by the Bay"
+    "description": "City by the Bay",
+    "type": "city"
   },
   {
     "title": "Paris",
     "lat": 48.8566,
     "lng": 2.3522,
-    "description": "City of Light"
+    "description": "City of Light",
+    "type": "city"
+  },
+  {
+    "title": "Smallville",
+    "lat": 38.8051,
+    "lng": -121.2945,
+    "description": "Fictional town",
+    "type": "town"
+  },
+  {
+    "title": "Stonehenge",
+    "lat": 51.1789,
+    "lng": -1.8262,
+    "description": "Ancient monument",
+    "type": "poi"
   }
 ]

--- a/script.js
+++ b/script.js
@@ -2,13 +2,54 @@ const map = L.map('map').setView([20,0],2);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
   attribution:'\u00a9 OpenStreetMap contributors'
 }).addTo(map);
+L.control.scale({metric:false}).addTo(map);
+
+const icons = {
+  city: new L.Icon({
+    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+    shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+    iconSize: [25,41],
+    iconAnchor: [12,41],
+    popupAnchor: [1,-34],
+    shadowSize: [41,41]
+  }),
+  town: new L.Icon({
+    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+    shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+    iconSize: [25,41],
+    iconAnchor: [12,41],
+    popupAnchor: [1,-34],
+    shadowSize: [41,41]
+  }),
+  poi: new L.Icon({
+    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-gold.png',
+    shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+    iconSize: [25,41],
+    iconAnchor: [12,41],
+    popupAnchor: [1,-34],
+    shadowSize: [41,41]
+  })
+};
+
+const groups = {
+  city: L.layerGroup().addTo(map),
+  town: L.layerGroup().addTo(map),
+  poi: L.layerGroup().addTo(map)
+};
 
 fetch('markers.json')
   .then(r=>r.json())
   .then(data=>{
     data.forEach(m=>{
-      L.marker([m.lat,m.lng]).addTo(map)
+      const icon = icons[m.type] || icons.poi;
+      const group = groups[m.type] || groups.poi;
+      L.marker([m.lat,m.lng],{icon}).addTo(group)
         .bindPopup(`<strong>${m.title}</strong><p>${m.description}</p>`);
     });
+    L.control.layers(null, {
+      'Cities': groups.city,
+      'Towns': groups.town,
+      'Points of Interest': groups.poi
+    }).addTo(map);
   })
   .catch(err=>console.error('Marker load failed',err));


### PR DESCRIPTION
## Summary
- categorize markers with city, town, and POI icons
- allow toggling categories via Leaflet layer control
- extend admin page and markers.json to store marker types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ea9c01b8832e8468f2f8cc31af04