### PR TITLE
Display marker details in side panel

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -7,3 +7,19 @@ body{
     height: 100%;
     margin: 0;
 }
+
+#info-panel {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 250px;
+    background: #fff;
+    border: 1px solid #333;
+    padding: 10px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    z-index: 1000;
+}
+
+.hidden {
+    display: none;
+}

--- a/index.html
+++ b/index.html
@@ -4,15 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dungeons Fantasy Map</title>
-    <script src="js/map.js"></script>
     <link rel="stylesheet" href="css/index.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
-     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
      
 </head>
 <body>
     <!-- <h1>map</h1> -->
     <div id="map"></div>
+    <div id="info-panel" class="hidden">
+        <h2 id="info-title"></h2>
+        <p id="info-description"></p>
+    </div>
     <script src="js/map.js"></script>
 </body>
 </html>

--- a/js/map.js
+++ b/js/map.js
@@ -11,6 +11,13 @@ var marker = L.marker([0, 0], {
   draggable: true,
 }).addTo(map);
 
+function showInfo(title, description) {
+  var panel = document.getElementById('info-panel');
+  document.getElementById('info-title').textContent = title;
+  document.getElementById('info-description').textContent = description;
+  panel.classList.remove('hidden');
+}
+
   var citiesIcon = L.icon({
 		iconUrl:       'icons/city.png',
 		iconRetinaUrl: 'icons/city.png',
@@ -54,10 +61,16 @@ var marker = L.marker([0, 0], {
 	});
   
 // //// START OF MARKERS
-//  1. Mage Colleges MARKERS
-var el_gulndar = L.marker([36.0135, -106.3916],{icon:TownsIcon}).bindPopup('<b>Gulndar</b>');
-var el_teglhus = L.marker([44.4965, -100.7666],{icon:TradingIcon}).bindPopup('<b>Teglhus</b>');
-var el_ochri_college = L.marker([48.5166,-103.4692],{icon:CollegesIcon}).bindPopup('<b>Ochri College</b>');
+// 1. Marker declarations
+function createMarker(lat, lng, icon, name, description) {
+  return L.marker([lat, lng], { icon: icon }).on('click', function () {
+    showInfo(name, description);
+  });
+}
+
+var el_gulndar = createMarker(36.0135, -106.3916, TownsIcon, 'Gulndar', 'A small but bustling town.');
+var el_teglhus = createMarker(44.4965, -100.7666, TradingIcon, 'Teglhus', 'A busy center of commerce.');
+var el_ochri_college = createMarker(48.5166, -103.4692, CollegesIcon, 'Ochri College', 'A renowned mage college.');
 //  2.Trading post markers
 
 // var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
@@ -122,3 +135,4 @@ marker.on('dragend', function(e) {
 map.on('zoomend', function (e) {
     console.log(e.target._zoom);
 });
+


### PR DESCRIPTION
## Summary
- Add left-side info panel to show marker details
- Style panel and hide it by default
- Show marker info when clicking map icons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b532dfc9d8832eadba00d3168811f8