### PR TITLE
Add close button to info panel

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -20,6 +20,16 @@ body{
     z-index: 1000;
 }
 
+#info-panel .close-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: transparent;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+}
+
 .hidden {
     display: none;
 }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <!-- <h1>map</h1> -->
     <div id="map"></div>
     <div id="info-panel" class="hidden">
+        <button id="close-info" class="close-button">&times;</button>
         <h2 id="info-title"></h2>
         <p id="info-description"></p>
     </div>

--- a/js/map.js
+++ b/js/map.js
@@ -18,6 +18,10 @@ function showInfo(title, description) {
   panel.classList.remove('hidden');
 }
 
+document.getElementById('close-info').addEventListener('click', function () {
+  document.getElementById('info-panel').classList.add('hidden');
+});
+
   var citiesIcon = L.icon({
 		iconUrl:       'icons/city.png',
 		iconRetinaUrl: 'icons/city.png',


### PR DESCRIPTION
## Summary
- Add close button to map info panel and style it for visibility
- Wire up button in JavaScript to hide info panel when clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b546bd780c832ea79b029b0bd673ae