### PR TITLE
Disable marker scaling during zoom

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,5 +1,8 @@
 //Creating the Map
-var map = L.map('map').setView([0, 0], 0);
+var map = L.map('map', {
+  zoomAnimation: false,
+  markerZoomAnimation: false
+}).setView([0, 0], 0);
 L.tileLayer('map/{z}/{x}/{y}.png', {
   continuousWorld: false,
   noWrap: true,  


### PR DESCRIPTION
## Summary
- Disable map zoom and marker animation to keep marker sizes fixed during zoom

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c81a29c0832e81d4912e02ac6d34