### PR TITLE
Remove Leaflet attribution link

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,7 +1,8 @@
 //Creating the Map
 var map = L.map('map', {
   zoomAnimation: false,
-  markerZoomAnimation: false
+  markerZoomAnimation: false,
+  attributionControl: false
 }).setView([0, 0], 0);
 L.tileLayer('map/{z}/{x}/{y}.png', {
   continuousWorld: false,


### PR DESCRIPTION
## Summary
- Disable Leaflet attribution control to hide the Leaflet link at the bottom of the map.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5caf8c35c832e94c7bc31e0ebaa37