### PR TITLE
Close info panel when map is clicked

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -26,6 +26,10 @@ document.getElementById('close-info').addEventListener('click', function () {
   document.getElementById('info-panel').classList.add('hidden');
 });
 
+map.on('click', function () {
+  document.getElementById('info-panel').classList.add('hidden');
+});
+
   var geographicalLocationsIcon = L.icon({
                 iconUrl:       'icons/city.png',
                 iconRetinaUrl: 'icons/city.png',
@@ -122,7 +126,8 @@ if (stored) {
 // //// START OF MARKERS
 // 1. Marker declarations
 function createMarker(lat, lng, icon, name, description) {
-  var m = L.marker([lat, lng], { icon: icon }).on('click', function () {
+  var m = L.marker([lat, lng], { icon: icon }).on('click', function (e) {
+    L.DomEvent.stopPropagation(e);
     showInfo(name, description);
   });
   m._baseIconOptions = JSON.parse(JSON.stringify(icon.options));


### PR DESCRIPTION
## Summary
- Hide info panel when clicking elsewhere on map
- Prevent marker clicks from propagating to map to keep info panel open

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6031628d4832e84f0ff8b06385f7c