### PR TITLE
Use viewport units for map container

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1,9 +1,9 @@
 #map{
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     background: #9CCDD1;
 }
-body{
+html, body{
     height: 100%;
     margin: 0;
 }


### PR DESCRIPTION
## Summary
- make the map container fill the viewport via 100vw/100vh
- ensure html and body have full height and no margins to prevent scrollbars

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx -y -p puppeteer node <<'NODE' ... NODE` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68b64ab93b80832ea1c61f757502e1df