### PR TITLE
Fix settlement icon path

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -41,8 +41,8 @@ map.on('click', function () {
 		shadowSize:  [41, 41]
 	});
   var SettlementsIcon = L.icon({
-                iconUrl:       'icons/townMill.png',
-                iconRetinaUrl: 'icons/townMill.png',
+                iconUrl:       'icons/settlement.png',
+                iconRetinaUrl: 'icons/settlement.png',
                 shadowUrl:     'icons/shadow.png',
                 iconSize:    [25, 41],
                 iconAnchor:  [12, 41],


### PR DESCRIPTION
## Summary
- point settlement markers to `settlement.png` icon so icons render correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6514860f4832ea7f52e3e64012334