### PR TITLE
Set Teglhus icon base size to 20

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -72,6 +72,18 @@ map.on('click', function () {
                 shadowSize:  [41, 41]
         });
 
+  // Teglhus settlement icon with a 20x20 base size
+  var TeglhusIcon = L.icon({
+                iconUrl:       'icons/settlement.png',
+                iconRetinaUrl: 'icons/settlement.png',
+                shadowUrl:     'icons/shadow.png',
+                iconSize:    [20, 20],
+                iconAnchor:  [10, 20],
+                popupAnchor: [1, -16],
+                tooltipAnchor: [10, -14],
+                shadowSize:  [20, 20]
+        });
+
 // Map of icon keys to actual icons
 var iconMap = {
   city: geographicalLocationsIcon,
@@ -136,7 +148,7 @@ function createMarker(lat, lng, icon, name, description) {
 }
 
 var el_gulndar = createMarker(36.0135, -106.3916, SachemdomsIcon, 'Gulndar', 'A small but bustling town.');
-var el_teglhus = createMarker(44.4965, -100.7666, TradingIcon, 'Teglhus', 'A busy center of commerce.');
+var el_teglhus = createMarker(44.4965, -100.7666, TeglhusIcon, 'Teglhus', 'A busy center of commerce.');
 var el_ochri_college = createMarker(48.5166, -103.4692, SettlementsIcon, 'Ochri College', 'A renowned mage college.');
 //  2.Trading post markers
 


### PR DESCRIPTION
## Summary
- Add a dedicated 20x20 base icon for Teglhus to ensure scalable sizing
- Use the new Teglhus icon for the Teglhus marker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b654c3301c832ead025b80fdd351e8