### PR TITLE
Use JPEG tiles for Leaflet map

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -4,7 +4,7 @@ var map = L.map('map', {
   markerZoomAnimation: true,
   attributionControl: false
 }).setView([0, 0], 0);
-L.tileLayer('map/{z}/{x}/{y}.png', {
+L.tileLayer('map/{z}/{x}/{y}.jpg', {
   continuousWorld: false,
   noWrap: true,
   minZoom: 2,


### PR DESCRIPTION
## Summary
- Switch Leaflet tile layer to load `.jpg` tiles instead of `.png`

## Testing
- `node /tmp/test-map.js`

------
https://chatgpt.com/codex/tasks/task_e_68b663b32034832e8e9e278563a7c895