### PR TITLE
Use settlement icon for Gulndar

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -131,7 +131,7 @@ function createMarker(lat, lng, icon, name, description) {
   return m;
 }
 
-var el_gulndar = createMarker(36.0135, -106.3916, SachemdomsIcon, 'Gulndar', 'A small but bustling town.');
+var el_gulndar = createMarker(36.0135, -106.3916, SettlementsIcon, 'Gulndar', 'A small but bustling town.');
 //  2.Trading post markers
 
 // var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
@@ -156,11 +156,11 @@ var el_gulndar = createMarker(36.0135, -106.3916, SachemdomsIcon, 'Gulndar', 'A 
 // ******END OF MARKERS DECLARATION ******
 
 // MARKER GROUPS
-var Sachemdoms = L.layerGroup([el_gulndar]).addTo(map);
+var Settlements = L.layerGroup([el_gulndar]).addTo(map);
 // Marker overlay
 var overlays= {
   // "GROUPNAME":mg_GROUPNAME
-   "Sachemdoms" : Sachemdoms,
+   "Settlements" : Settlements,
 }
 
 //GROUP CONTROLS


### PR DESCRIPTION
## Summary
- Display Gulndar with the settlement icon instead of the sachemdom marker
- Update map layer group and overlay label accordingly

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b665f270e4832ea98d9f09e18e29ea