### PR TITLE
Resize map icons to 15x15 with centered anchors

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -41,35 +41,35 @@ map.on('click', function () {
   var geographicalLocationsIcon = L.icon({
                 iconUrl:       'icons/city.png',
                 iconRetinaUrl: 'icons/city.png',
-                iconSize:    [25, 41],
-                iconAnchor:  [12, 41],
-                popupAnchor: [1, -34],
-                tooltipAnchor: [16, -28]
+                iconSize:    [15, 15],
+                iconAnchor:  [7, 15],
+                popupAnchor: [1, -15],
+                tooltipAnchor: [7, -7]
         });
   var SettlementsIcon = L.icon({
                 iconUrl:       'icons/settlement.png',
                 iconRetinaUrl: 'icons/settlement.png',
-                iconSize:    [25, 41],
-                iconAnchor:  [12, 41],
-                popupAnchor: [1, -34],
-                tooltipAnchor: [16, -28]
+                iconSize:    [15, 15],
+                iconAnchor:  [7, 15],
+                popupAnchor: [1, -15],
+                tooltipAnchor: [7, -7]
         });
   var SachemdomsIcon = L.icon({
                 iconUrl:       'icons/town.png',
                 iconRetinaUrl: 'icons/town.png',
-                iconSize:    [25, 41],
-                iconAnchor:  [12, 41],
-                popupAnchor: [1, -34],
-                tooltipAnchor: [16, -28]
+                iconSize:    [15, 15],
+                iconAnchor:  [7, 15],
+                popupAnchor: [1, -15],
+                tooltipAnchor: [7, -7]
         });
   // Trading
   var TradingIcon = L.icon({
                 iconUrl:       'icons/tradeCamp.png',
                 iconRetinaUrl: 'icons/tradecamplarge.png',
-                iconSize:    [25, 41],
-                iconAnchor:  [12, 41],
-                popupAnchor: [1, -34],
-                tooltipAnchor: [16, -28]
+                iconSize:    [15, 15],
+                iconAnchor:  [7, 15],
+                popupAnchor: [1, -15],
+                tooltipAnchor: [7, -7]
         });
 
 


### PR DESCRIPTION
## Summary
- shrink base icon sizes to 15×15
- center markers with adjusted icon and tooltip anchors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b673005a1c832e9d20ab88a32be4d2