### PR TITLE
feat: move add marker control

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
 <body>
     <!-- <h1>map</h1> -->
     <div id="map"></div>
-    <button id="add-marker-btn">Add Marker</button>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>
         <h2 id="info-title"></h2>

--- a/js/map.js
+++ b/js/map.js
@@ -176,24 +176,43 @@ var overlays= {
 
 map.on('zoomend', rescaleIcons);
 
-// Add marker button handler
-document.getElementById('add-marker-btn').addEventListener('click', function () {
-  alert('Click on the map to place the marker.');
-  map.once('click', function (e) {
-    var name = prompt('Enter marker name:') || 'Marker';
-    var description = prompt('Enter description:') || '';
-    var iconKey = prompt('Enter icon (city, settlement, sachemdom, trading):', 'city') || 'city';
-    var data = {
-      lat: e.latlng.lat,
-      lng: e.latlng.lng,
-      name: name,
-      description: description,
-      icon: iconKey,
-    };
-    addMarkerToMap(data);
-    customMarkers.push(data);
-    saveMarkers();
-  });
+var AddMarkerControl = L.Control.extend({
+  options: { position: 'topleft' },
+  onAdd: function (map) {
+    var container = L.DomUtil.create('div', 'leaflet-bar');
+    var link = L.DomUtil.create('a', '', container);
+    link.id = 'add-marker-btn';
+    link.href = '#';
+    link.title = 'Add Marker';
+    link.innerHTML = '+';
+    L.DomEvent.on(link, 'click', L.DomEvent.stopPropagation)
+      .on(link, 'click', L.DomEvent.preventDefault)
+      .on(link, 'click', function () {
+        alert('Click on the map to place the marker.');
+        map.once('click', function (e) {
+          var name = prompt('Enter marker name:') || 'Marker';
+          var description = prompt('Enter description:') || '';
+          var iconKey =
+            prompt(
+              'Enter icon (city, settlement, sachemdom, trading):',
+              'city'
+            ) || 'city';
+          var data = {
+            lat: e.latlng.lat,
+            lng: e.latlng.lng,
+            name: name,
+            description: description,
+            icon: iconKey,
+          };
+          addMarkerToMap(data);
+          customMarkers.push(data);
+          saveMarkers();
+        });
+      });
+    return container;
+  },
 });
+
+map.addControl(new AddMarkerControl());
 
 


### PR DESCRIPTION
## Summary
- replace standalone Add Marker button with Leaflet control next to zoom buttons
- remove obsolete button from HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b677349d20832e80c7c287bcc08259