### PR TITLE
Reduce settlement icon size

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -49,10 +49,10 @@ map.on('click', function () {
   var SettlementsIcon = L.icon({
                 iconUrl:       'icons/settlement.png',
                 iconRetinaUrl: 'icons/settlement.png',
-                iconSize:    [15, 15],
-                iconAnchor:  [7, 15],
-                popupAnchor: [1, -15],
-                tooltipAnchor: [7, -7]
+                iconSize:    [3.75, 3.75],
+                iconAnchor:  [1.75, 3.75],
+                popupAnchor: [0.25, -3.75],
+                tooltipAnchor: [1.75, -1.75]
         });
   var SachemdomsIcon = L.icon({
                 iconUrl:       'icons/town.png',


### PR DESCRIPTION
## Summary
- Shrink settlement map marker to 25% of its original size by scaling icon dimensions and anchors.

## Testing
- `node --check js/map.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67ae472e8832eaa3676a33d5ca1d8