### PR TITLE
Reduce settlement icon size to 50%

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -49,10 +49,10 @@ map.on('click', function () {
   var SettlementsIcon = L.icon({
                 iconUrl:       'icons/settlement.png',
                 iconRetinaUrl: 'icons/settlement.png',
-                iconSize:    [15, 15],
-                iconAnchor:  [7, 15],
-                popupAnchor: [1, -15],
-                tooltipAnchor: [7, -7]
+                iconSize:    [7.5, 7.5],
+                iconAnchor:  [3.5, 7.5],
+                popupAnchor: [0.5, -7.5],
+                tooltipAnchor: [3.5, -3.5]
         });
   var SachemdomsIcon = L.icon({
                 iconUrl:       'icons/town.png',


### PR DESCRIPTION
## Summary
- Shrink settlement map marker to 50% of its original size by adjusting icon dimensions and anchors.

## Testing
- `node --check js/map.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67ae472e8832eaa3676a33d5ca1d8