### PR TITLE
Correct Settlement icon anchor arrays

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -51,9 +51,9 @@ map.on('click', function () {
                 iconRetinaUrl: 'icons/settlement.png',
 
                 iconSize:    [3.75, 3.75],
-                iconAnchor:  1.75, 3.75],
-                popupAnchor: 0.25, -3.75],
-                tooltipAnchor: 1.75, -1.75]
+                iconAnchor:  [1.75, 3.75],
+                popupAnchor: [0.25, -3.75],
+                tooltipAnchor: [1.75, -1.75]
 
 
         });


### PR DESCRIPTION
## Summary
- fix Settlement icon anchor definitions to use array syntax

## Testing
- `node --check js/map.js`
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000` (served index.html; verified with `curl -I http://localhost:8000/index.html`)


------
https://chatgpt.com/codex/tasks/task_e_68b697b11524832eb45e9705b0b9c7f5