### PR TITLE
Center info panel text for map icons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -20,6 +20,11 @@ html, body{
     z-index: 1000;
 }
 
+#info-title,
+#info-description {
+    text-align: center;
+}
+
 #info-panel .close-button {
     position: absolute;
     top: 5px;


### PR DESCRIPTION
## Summary
- center title and description in the info panel that appears when clicking map icons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7384bf2f0832e919e7f78a48ffe01