### PR TITLE
Rescale markers dynamically during zoom

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -94,15 +94,11 @@ function rescaleIcons() {
     baseZoom = map.getZoom();
   }
   var scale = Math.pow(2, map.getZoom() - baseZoom);
-  allMarkers.forEach(function (m) {
-    var base = m._baseIconOptions;
-    var opts = Object.assign({}, base);
-    if (base.iconSize) opts.iconSize = base.iconSize.map(function (v) { return v * scale; });
-    if (base.iconAnchor) opts.iconAnchor = base.iconAnchor.map(function (v) { return v * scale; });
-    if (base.shadowSize) opts.shadowSize = base.shadowSize.map(function (v) { return v * scale; });
-    if (base.popupAnchor) opts.popupAnchor = base.popupAnchor.map(function (v) { return v * scale; });
-    if (base.tooltipAnchor) opts.tooltipAnchor = base.tooltipAnchor.map(function (v) { return v * scale; });
-    m.setIcon(L.icon(opts));
+  allMarkers.forEach(m => {
+    if (m._icon) {
+      m._icon.style.transform = `scale(${scale})`;
+      m._icon.style.transformOrigin = 'center bottom';
+    }
   });
 }
 
@@ -177,7 +173,7 @@ var overlays= {
 //GROUP CONTROLS
   L.control.layers(null, overlays).addTo(map);
 
-map.on('zoomend', rescaleIcons);
+map.on('zoom', rescaleIcons);
 
 var AddMarkerControl = L.Control.extend({
   options: { position: 'topleft' },


### PR DESCRIPTION
## Summary
- Recalculate marker icon sizes continuously during zoom by applying CSS scaling
- Switch zoom listener to `zoom` to update icons during animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b73b6c5550832ea2d01abfd28271c0