### PR TITLE
Highlight selected map markers

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -38,3 +38,7 @@ html, body{
 .hidden {
     display: none;
 }
+
+.marker-selected {
+    filter: drop-shadow(0 0 5px gold);
+}

--- a/js/map.js
+++ b/js/map.js
@@ -32,10 +32,12 @@ function showInfo(title, description) {
 
 document.getElementById('close-info').addEventListener('click', function () {
   document.getElementById('info-panel').classList.add('hidden');
+  clearSelectedMarker();
 });
 
 map.on('click', function () {
   document.getElementById('info-panel').classList.add('hidden');
+  clearSelectedMarker();
 });
 
   var geographicalLocationsIcon = L.icon({
@@ -88,6 +90,14 @@ var iconMap = {
 var customMarkers = [];
 var allMarkers = [];
 var baseZoom;
+var selectedMarker = null;
+
+function clearSelectedMarker() {
+  if (selectedMarker && selectedMarker._icon) {
+    selectedMarker._icon.classList.remove('marker-selected');
+    selectedMarker = null;
+  }
+}
 
 function rescaleIcons() {
   if (baseZoom === undefined) {
@@ -131,6 +141,11 @@ if (stored) {
 function createMarker(lat, lng, icon, name, description) {
   var m = L.marker([lat, lng], { icon: icon }).on('click', function (e) {
     L.DomEvent.stopPropagation(e);
+    clearSelectedMarker();
+    if (this._icon) {
+      this._icon.classList.add('marker-selected');
+      selectedMarker = this;
+    }
     showInfo(name, description);
   });
   m._baseIconOptions = JSON.parse(JSON.stringify(icon.options));


### PR DESCRIPTION
## Summary
- Add `.marker-selected` class to style selected markers with a drop-shadow glow.
- Track the currently selected marker and manage selection state in `map.js`.
- Clear selection on map or info panel interactions to avoid stale highlighting.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f34553c832e90e50836ddab7532