### PR TITLE
Add text overlay control for Leaflet map

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -42,3 +42,10 @@ html, body{
 .marker-selected {
     filter: drop-shadow(0 0 5px gold);
 }
+
+/* Style for text markers */
+.text-label span {
+    font-family: 'Roboto', 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
+    font-weight: bold;
+    color: #333;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Indigenous History Map</title>
     <link rel="stylesheet" href="css/index.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Open+Sans:wght@400;700&display=swap">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
      

--- a/js/map.js
+++ b/js/map.js
@@ -233,4 +233,37 @@ var AddMarkerControl = L.Control.extend({
 
 map.addControl(new AddMarkerControl());
 
+// Control to add text labels
+var AddTextControl = L.Control.extend({
+  options: { position: 'topleft' },
+  onAdd: function (map) {
+    var container = L.DomUtil.create('div', 'leaflet-bar');
+    var link = L.DomUtil.create('a', '', container);
+    link.id = 'add-text-btn';
+    link.href = '#';
+    link.title = 'Add Text';
+    link.innerHTML = 'T';
+    L.DomEvent.on(link, 'click', L.DomEvent.stopPropagation)
+      .on(link, 'click', L.DomEvent.preventDefault)
+      .on(link, 'click', function () {
+        alert('Click on the map to place the text.');
+        map.once('click', function (e) {
+          var text = prompt('Enter text:') || '';
+          if (!text) return;
+          var size = parseInt(prompt('Enter text size in pixels:', '14'), 10) || 14;
+          var textIcon = L.divIcon({
+            className: 'text-label',
+            html: '<span style="font-size:' + size + 'px">' + text + '</span>',
+          });
+          L.marker(e.latlng, { icon: textIcon })
+            .bindPopup(text)
+            .addTo(map);
+        });
+      });
+    return container;
+  },
+});
+
+map.addControl(new AddTextControl());
+
 


### PR DESCRIPTION
## Summary
- allow placing custom text markers with selectable size using new Add Text button
- load Google Fonts and styling for text markers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b733003398832e8d66dc77eef85ab9