### PR TITLE
Enable right-click deletion of text labels

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -170,6 +170,22 @@ function addTextLabelToMap(data) {
       }
       showInfo(data.text, data.description);
     })
+    .on('contextmenu', function () {
+      map.removeLayer(m);
+      customTextLabels = customTextLabels.filter(function (t) {
+        return !(
+          t.lat === data.lat &&
+          t.lng === data.lng &&
+          t.text === data.text &&
+          t.size === data.size &&
+          t.description === data.description
+        );
+      });
+      allTextLabels = allTextLabels.filter(function (t) {
+        return t !== m;
+      });
+      saveTextLabels();
+    })
     .addTo(map);
   m._baseFontSize = data.size;
   allTextLabels.push(m);


### PR DESCRIPTION
## Summary
- allow right-clicking text labels to remove them from the map and local storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b773864abc832ea6758d26ff0fa150