### PR TITLE
Ensure marker form overlay hides when marked hidden

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -64,6 +64,10 @@ html, body{
     z-index: 10000;
 }
 
+#marker-form-overlay.hidden {
+    display: none;
+}
+
 #marker-form {
     background: #fff;
     padding: 15px;


### PR DESCRIPTION
## Summary
- Override marker form overlay flex display when hidden class is present

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --prefix /tmp/playwright playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7860dfc74832eb625dc29ad2c00c6