### PR TITLE
Match rock icon size to wigwam

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -72,10 +72,10 @@ map.on('click', function () {
   var TradingIcon = L.icon({
                 iconUrl:       'icons/rock.png',
                 iconRetinaUrl: 'icons/rock.png',
-                iconSize:    [15, 15],
-                iconAnchor:  [7, 15],
-                popupAnchor: [1, -15],
-                tooltipAnchor: [7, -7]
+                iconSize:    [1.25, 1.25],
+                iconAnchor:  [0.625, 1.25],
+                popupAnchor: [0.125, -1.25],
+                tooltipAnchor: [0.625, -0.625]
         });
 
 


### PR DESCRIPTION
## Summary
- Resize trading marker to use rock.png at the same dimensions as wigwam.png.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b797a9d590832e9f3addff462171cb