### PR TITLE
Use capital icon for sachemdom marker

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -61,8 +61,8 @@ map.on('click', function () {
 
         });
   var SachemdomsIcon = L.icon({
-                iconUrl:       'icons/town.png',
-                iconRetinaUrl: 'icons/town.png',
+                iconUrl:       'icons/capital.png',
+                iconRetinaUrl: 'icons/capital.png',
                 iconSize:    [15, 15],
                 iconAnchor:  [7, 15],
                 popupAnchor: [1, -15],


### PR DESCRIPTION
## Summary
- point sachemdom markers to the `capital.png` icon instead of the outdated `town.png` file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c31b098832ead604566f50d49b3