### PR TITLE
feat: add unified text label creation form

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -49,3 +49,54 @@ html, body{
     font-weight: bold;
     color: #333;
 }
+
+/* Marker form styles */
+#marker-form-overlay,
+#text-form-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+#marker-form-overlay.hidden,
+#text-form-overlay.hidden {
+    display: none;
+}
+
+#marker-form,
+#text-form {
+    background: #fff;
+    padding: 15px;
+    border: 1px solid #333;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    width: 300px;
+}
+
+#marker-form label,
+#text-form label {
+    display: block;
+    margin-bottom: 8px;
+}
+
+#marker-form input,
+#marker-form select,
+#marker-form textarea,
+#text-form input,
+#text-form select,
+#text-form textarea {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+#marker-form button,
+#text-form button {
+    margin-top: 10px;
+    margin-right: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,43 @@
         <h2 id="info-title"></h2>
         <p id="info-description"></p>
     </div>
+    <div id="marker-form-overlay" class="hidden">
+        <div id="marker-form">
+            <h3>Add Marker</h3>
+            <label>Name:
+                <input type="text" id="marker-name">
+            </label>
+            <label>Description:
+                <textarea id="marker-description"></textarea>
+            </label>
+            <label>Icon:
+                <select id="marker-icon">
+                    <option value="city">City</option>
+                    <option value="settlement">Settlement</option>
+                    <option value="sachemdom">Sachemdom</option>
+                    <option value="trading">Trading</option>
+                </select>
+            </label>
+            <button id="marker-save">Save</button>
+            <button id="marker-cancel">Cancel</button>
+        </div>
+    </div>
+    <div id="text-form-overlay" class="hidden">
+        <div id="text-form">
+            <h3>Add Text Label</h3>
+            <label>Text:
+                <input type="text" id="text-text">
+            </label>
+            <label>Description:
+                <textarea id="text-description"></textarea>
+            </label>
+            <label>Size (px):
+                <input type="number" id="text-size" value="14">
+            </label>
+            <button id="text-save">Save</button>
+            <button id="text-cancel">Cancel</button>
+        </div>
+    </div>
     <script src="js/map.js"></script>
 </body>
 </html>

--- a/js/map.js
+++ b/js/map.js
@@ -260,6 +260,47 @@ var overlays= {
 map.on('zoomend', rescaleIcons);
 map.on('zoomend', rescaleTextLabels);
 
+function showMarkerForm(latlng) {
+  var overlay = document.getElementById('marker-form-overlay');
+  var saveBtn = document.getElementById('marker-save');
+  var cancelBtn = document.getElementById('marker-cancel');
+  overlay.classList.remove('hidden');
+
+  function submitHandler() {
+    var name = document.getElementById('marker-name').value || 'Marker';
+    var description =
+      document.getElementById('marker-description').value || '';
+    var iconKey = document.getElementById('marker-icon').value || 'city';
+    var data = {
+      lat: latlng.lat,
+      lng: latlng.lng,
+      name: name,
+      description: description,
+      icon: iconKey,
+    };
+    addMarkerToMap(data);
+    customMarkers.push(data);
+    saveMarkers();
+    cleanup();
+  }
+
+  function cancelHandler() {
+    cleanup();
+  }
+
+  function cleanup() {
+    overlay.classList.add('hidden');
+    saveBtn.removeEventListener('click', submitHandler);
+    cancelBtn.removeEventListener('click', cancelHandler);
+    document.getElementById('marker-name').value = '';
+    document.getElementById('marker-description').value = '';
+    document.getElementById('marker-icon').value = 'city';
+  }
+
+  saveBtn.addEventListener('click', submitHandler);
+  cancelBtn.addEventListener('click', cancelHandler);
+}
+
 var AddMarkerControl = L.Control.extend({
   options: { position: 'topleft' },
   onAdd: function (map) {
@@ -274,23 +315,7 @@ var AddMarkerControl = L.Control.extend({
       .on(link, 'click', function () {
         alert('Click on the map to place the marker.');
         map.once('click', function (e) {
-          var name = prompt('Enter marker name:') || 'Marker';
-          var description = prompt('Enter description:') || '';
-          var iconKey =
-            prompt(
-              'Enter icon (city, settlement, sachemdom, trading):',
-              'city'
-            ) || 'city';
-          var data = {
-            lat: e.latlng.lat,
-            lng: e.latlng.lng,
-            name: name,
-            description: description,
-            icon: iconKey,
-          };
-          addMarkerToMap(data);
-          customMarkers.push(data);
-          saveMarkers();
+          showMarkerForm(e.latlng);
         });
       });
     return container;
@@ -298,6 +323,51 @@ var AddMarkerControl = L.Control.extend({
 });
 
 map.addControl(new AddMarkerControl());
+
+function showTextForm(latlng) {
+  var overlay = document.getElementById('text-form-overlay');
+  var saveBtn = document.getElementById('text-save');
+  var cancelBtn = document.getElementById('text-cancel');
+  overlay.classList.remove('hidden');
+
+  function submitHandler() {
+    var text = document.getElementById('text-text').value || '';
+    if (!text) {
+      cleanup();
+      return;
+    }
+    var size =
+      parseInt(document.getElementById('text-size').value, 10) || 14;
+    var description = document.getElementById('text-description').value || '';
+    var data = {
+      lat: latlng.lat,
+      lng: latlng.lng,
+      text: text,
+      size: size,
+      description: description,
+    };
+    addTextLabelToMap(data);
+    customTextLabels.push(data);
+    saveTextLabels();
+    cleanup();
+  }
+
+  function cancelHandler() {
+    cleanup();
+  }
+
+  function cleanup() {
+    overlay.classList.add('hidden');
+    saveBtn.removeEventListener('click', submitHandler);
+    cancelBtn.removeEventListener('click', cancelHandler);
+    document.getElementById('text-text').value = '';
+    document.getElementById('text-size').value = '14';
+    document.getElementById('text-description').value = '';
+  }
+
+  saveBtn.addEventListener('click', submitHandler);
+  cancelBtn.addEventListener('click', cancelHandler);
+}
 
 // Control to add text labels
 var AddTextControl = L.Control.extend({
@@ -314,20 +384,7 @@ var AddTextControl = L.Control.extend({
       .on(link, 'click', function () {
         alert('Click on the map to place the text.');
         map.once('click', function (e) {
-          var text = prompt('Enter text:') || '';
-          if (!text) return;
-          var size = parseInt(prompt('Enter text size in pixels:', '14'), 10) || 14;
-          var description = prompt('Enter description:') || '';
-          var data = {
-            lat: e.latlng.lat,
-            lng: e.latlng.lng,
-            text: text,
-            size: size,
-            description: description,
-          };
-          addTextLabelToMap(data);
-          customTextLabels.push(data);
-          saveTextLabels();
+          showTextForm(e.latlng);
         });
       });
     return container;


### PR DESCRIPTION
## Summary
- add modal form to create text markers with label, description, and size at once
- share styling for marker and text modals and hide overlays when inactive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b781477244832e90b55b4c2070fc4d