### PR TITLE
Render sanitized Markdown in info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
                 <input type="text" id="marker-name">
             </label>
             <label>Description:
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
                 <textarea id="marker-description"></textarea>
             </label>
             <label>Icon:
@@ -40,5 +41,7 @@
         </div>
     </div>
     <script src="js/map.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
 </body>
 </html>

--- a/js/map.js
+++ b/js/map.js
@@ -27,7 +27,8 @@ L.Icon.Default.mergeOptions({
 function showInfo(title, description) {
   var panel = document.getElementById('info-panel');
   document.getElementById('info-title').textContent = title;
-  document.getElementById('info-description').textContent = description;
+  const html = DOMPurify.sanitize(marked.parse(description));
+  document.getElementById('info-description').innerHTML = html;
   panel.classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- load Marked and DOMPurify in the page
- render marker descriptions as sanitized HTML
- note Markdown support next to description input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cc4f0614832e818c742225335fbd