### PR TITLE
Add hover glow effect for map markers

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -39,6 +39,8 @@ html, body{
     display: none;
 }
 
+/* Glow effect for markers */
+.leaflet-marker-icon:hover,
 .marker-selected {
     filter: drop-shadow(0 0 5px gold);
 }


### PR DESCRIPTION
## Summary
- Glow map icons when hovered using CSS filter
- Maintain glow for clicked markers via existing `marker-selected` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7daa08754832eb2c9de094ccef459