### PR TITLE
Center text labels on map

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -46,6 +46,13 @@ html, body{
 }
 
 /* Style for text markers */
+.text-label {
+    position: relative;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
 .text-label span {
     font-family: 'Roboto', 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
     font-weight: bold;

--- a/js/map.js
+++ b/js/map.js
@@ -203,6 +203,7 @@ function addTextLabelToMap(data) {
   var textIcon = L.divIcon({
     className: 'text-label',
     html: '<span style="font-size:' + data.size + 'px">' + data.text + '</span>',
+    iconAnchor: [0, 0],
   });
   var m = L.marker([data.lat, data.lng], { icon: textIcon, draggable: true })
     .on('click', function (ev) {


### PR DESCRIPTION
## Summary
- Anchor text label icons so CSS can position them from the marker point
- Add CSS rules to center label text over map coordinates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b858de7f24832eaaa896791df4a4ab