### PR TITLE
feat: add letter spacing slider for text labels

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -58,10 +58,12 @@ html, body{
     font-weight: bold;
     color: #333;
     display: inline-block;
+    letter-spacing: 0;
 }
 
 /* Marker form styles */
-#marker-form-overlay {
+#marker-form-overlay,
+#text-form-overlay {
     position: fixed;
     top: 0;
     left: 0;
@@ -74,11 +76,13 @@ html, body{
     z-index: 10000;
 }
 
-#marker-form-overlay.hidden {
+#marker-form-overlay.hidden,
+#text-form-overlay.hidden {
     display: none;
 }
 
-#marker-form {
+#marker-form,
+#text-form {
     background: #fff;
     padding: 15px;
     border: 1px solid #333;
@@ -86,19 +90,24 @@ html, body{
     width: 300px;
 }
 
-#marker-form label {
+#marker-form label,
+#text-form label {
     display: block;
     margin-bottom: 8px;
 }
 
 #marker-form input,
 #marker-form select,
-#marker-form textarea {
+#marker-form textarea,
+#text-form input,
+#text-form select,
+#text-form textarea {
     width: 100%;
     box-sizing: border-box;
 }
 
-#marker-form button {
+#marker-form button,
+#text-form button {
     margin-top: 10px;
     margin-right: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -40,6 +40,29 @@
             <button id="marker-cancel">Cancel</button>
         </div>
     </div>
+    <div id="text-form-overlay" class="hidden">
+        <div id="text-form">
+            <h3>Add Text</h3>
+            <label>Text:
+                <input type="text" id="text-label-text">
+            </label>
+            <label>Description:
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
+                <textarea id="text-label-description"></textarea>
+            </label>
+            <label>Size:
+                <input type="number" id="text-label-size" value="14">
+            </label>
+            <label>Angle:
+                <input type="number" id="text-label-angle" value="0">
+            </label>
+            <label>Letter Spacing:
+                <input type="range" id="text-letter-spacing" min="-5" max="20" value="0">
+            </label>
+            <button id="text-save">Save</button>
+            <button id="text-cancel">Cancel</button>
+        </div>
+    </div>
     <script src="js/map.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>


### PR DESCRIPTION
## Summary
- add form overlay for text labels with letter-spacing slider
- persist and scale custom letter spacing for text annotations
- share form styling and set default letter-spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86d8d8fe0832ea92a9d3b513b2857