### PR TITLE
Fix text label positioning to prevent drift

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -47,9 +47,7 @@ html, body{
 
 /* Style for text markers */
 .text-label {
-    position: relative;
-    left: 50%;
-    top: 50%;
+    position: absolute;
     transform: translate(-50%, -50%);
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- Replace `.text-label` CSS rule to use absolute positioning and center via transform
- Remove `left` and `top` offsets so label centers remain anchored at map coordinates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000 & curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b88b794500832e8397e6e36a9cda2f