### PR TITLE
Shift info panel to avoid covering controls

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -11,7 +11,7 @@ html, body{
 #info-panel {
     position: absolute;
     top: 10px;
-    left: 10px;
+    left: 60px;
     width: 250px;
     background: #fff;
     border: 1px solid #333;


### PR DESCRIPTION
## Summary
- Move info panel 60px from the left edge so it doesn't cover map control buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9552b8254832e9cc563b05f643dc6