### PR TITLE
Use fish1 icon for fishing markers

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -79,7 +79,7 @@ map.on('click', function () {
                 tooltipAnchor: [0.625, -0.625]
         });
   // Fishing
-  var fishingIconPath = 'icons/fish.png';
+  var fishingIconPath = 'icons/fish1.png';
   var FishingIcon = L.icon({
                 iconUrl:       fishingIconPath,
                 iconRetinaUrl: fishingIconPath,


### PR DESCRIPTION
## Summary
- swap fishing marker icon to use `fish1` image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba16c2cf20832e990a85d2fe9983d3