### PR TITLE
Add polygon form overlay to style and save metadata

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -64,7 +64,8 @@ html, body{
 
 /* Marker form styles */
 #marker-form-overlay,
-#text-form-overlay {
+#text-form-overlay,
+#polygon-form-overlay {
     position: fixed;
     top: 0;
     left: 0;
@@ -78,12 +79,14 @@ html, body{
 }
 
 #marker-form-overlay.hidden,
-#text-form-overlay.hidden {
+#text-form-overlay.hidden,
+#polygon-form-overlay.hidden {
     display: none;
 }
 
 #marker-form,
-#text-form {
+#text-form,
+#polygon-form {
     background: #fff;
     padding: 15px;
     border: 1px solid #333;
@@ -92,7 +95,8 @@ html, body{
 }
 
 #marker-form label,
-#text-form label {
+#text-form label,
+#polygon-form label {
     display: block;
     margin-bottom: 8px;
 }
@@ -102,13 +106,17 @@ html, body{
 #marker-form textarea,
 #text-form input,
 #text-form select,
-#text-form textarea {
+#text-form textarea,
+#polygon-form input,
+#polygon-form select,
+#polygon-form textarea {
     width: 100%;
     box-sizing: border-box;
 }
 
 #marker-form button,
-#text-form button {
+#text-form button,
+#polygon-form button {
     margin-top: 10px;
     margin-right: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -49,6 +49,23 @@
             <button id="marker-cancel">Cancel</button>
         </div>
     </div>
+    <div id="polygon-form-overlay" class="hidden">
+        <div id="polygon-form">
+            <h3>Add Polygon</h3>
+            <label>Name:
+                <input type="text" id="polygon-name">
+            </label>
+            <label>Description:
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
+                <textarea id="polygon-description"></textarea>
+            </label>
+            <label>Color:
+                <input type="color" id="polygon-color" value="#3388ff">
+            </label>
+            <button id="polygon-save">Save</button>
+            <button id="polygon-cancel">Cancel</button>
+        </div>
+    </div>
     <div id="text-form-overlay" class="hidden">
         <div id="text-form">
             <h3>Add Text</h3>

--- a/js/map.js
+++ b/js/map.js
@@ -526,6 +526,50 @@ var overlays = {
 map.on('zoomend', rescaleIcons);
 map.on('zoomend', rescaleTextLabels);
 
+function showPolygonForm(tempLayer) {
+  var overlay = document.getElementById('polygon-form-overlay');
+  var saveBtn = document.getElementById('polygon-save');
+  var cancelBtn = document.getElementById('polygon-cancel');
+  overlay.classList.remove('hidden');
+
+  function submitHandler() {
+    var name = document.getElementById('polygon-name').value || 'Territory';
+    var description = document.getElementById('polygon-description').value || '';
+    var color = document.getElementById('polygon-color').value || '#3388ff';
+    var coords = tempLayer.getLatLngs()[0].map(function (latlng) {
+      return [latlng.lat, latlng.lng];
+    });
+    var data = {
+      name: name,
+      description: description,
+      coords: coords,
+      style: { color: color, fillColor: color, fillOpacity: 0.3 },
+    };
+    customPolygons.push(data);
+    addPolygonToMap(data);
+    savePolygons();
+    map.removeLayer(tempLayer);
+    cleanup();
+  }
+
+  function cancelHandler() {
+    map.removeLayer(tempLayer);
+    cleanup();
+  }
+
+  function cleanup() {
+    overlay.classList.add('hidden');
+    saveBtn.removeEventListener('click', submitHandler);
+    cancelBtn.removeEventListener('click', cancelHandler);
+    document.getElementById('polygon-name').value = '';
+    document.getElementById('polygon-description').value = '';
+    document.getElementById('polygon-color').value = '#3388ff';
+  }
+
+  saveBtn.addEventListener('click', submitHandler);
+  cancelBtn.addEventListener('click', cancelHandler);
+}
+
 function showMarkerForm(latlng) {
   var overlay = document.getElementById('marker-form-overlay');
   var saveBtn = document.getElementById('marker-save');
@@ -850,21 +894,7 @@ updateEditToolbar();
 
 map.on(L.Draw.Event.CREATED, function (e) {
   if (e.layerType === 'polygon') {
-    var coords = e.layer.getLatLngs()[0].map(function (latlng) {
-      return [latlng.lat, latlng.lng];
-    });
-    var name = prompt('Enter territory name:') || 'Territory';
-    var description = prompt('Enter description:') || '';
-    var color = prompt('Enter hex color for polygon:', '#3388ff') || '#3388ff';
-    var data = {
-      name: name,
-      description: description,
-      coords: coords,
-      style: { color: color, fillColor: color, fillOpacity: 0.3 },
-    };
-    customPolygons.push(data);
-    addPolygonToMap(data);
-    savePolygons();
+    showPolygonForm(e.layer);
   }
 });
 


### PR DESCRIPTION
## Summary
- Add polygon creation overlay to capture name, description, and color
- Style polygon overlay with existing form styles
- Show overlay after drawing a polygon and save its data and style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba78bc0ad8832e83ea60e2b01dc9fa