### PR TITLE
feat: add GitHub-backed feature saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,16 @@ This project is a web-based map using Leaflet. Users can add custom markers, tex
 
 ## Feature Export
 
-Whenever markers, text labels, or polygons are saved, the map generates a CSV representation and tries to POST it to `data/features.csv`. If the request succeeds (HTTP 200), the file is overwritten on the server. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.
+Whenever markers, text labels, or polygons are saved, the map generates a CSV representation and tries to POST it to `/save-features`. If the request succeeds (HTTP 200), the file is committed to the GitHub repository. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.
 
 Each row of the CSV includes a `type` column identifying the feature (`marker`, `text`, or `polygon`) followed by relevant attributes such as coordinates, label text, and style information.
 
-For persistent storage, run the Express server in `server/index.js`:
+For persistent storage, run the Express server in `server/index.js` with the following environment variables:
 
 ```
-npm install express
-node server/index.js
+GITHUB_TOKEN=your_token GITHUB_OWNER=owner GITHUB_REPO=repo node server/index.js
 ```
 
-The server exposes a `POST /data/features.csv` route that writes the uploaded CSV to `data/features.csv`. Without this server the CSV will only be downloaded on the client.
+The server exposes a `POST /save-features` route that commits the uploaded CSV to `data/features.csv` in the specified GitHub repository. Without this server the CSV will only be downloaded on the client.
 
 The initial CSV file lives at `data/features.csv` and can be used as a template for further exports.

--- a/js/map.js
+++ b/js/map.js
@@ -371,10 +371,10 @@ function exportFeaturesToCSV() {
   var csvContent = rows.join('\n');
 
   // Try posting to a server endpoint; fall back to client-side download
-  fetch('data/features.csv', {
+  fetch('/save-features', {
     method: 'POST',
-    headers: { 'Content-Type': 'text/csv' },
-    body: csvContent
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: btoa(csvContent) })
   })
     .then(function (response) {
       if (!response.ok) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,22 +1,67 @@
 const express = require('express');
-const fs = require('fs');
-const path = require('path');
-
 const app = express();
 
-// accept raw CSV payloads
-app.use(express.text({ type: 'text/csv' }));
+// Parse JSON bodies
+app.use(express.json({ limit: '10mb' }));
 
-// Endpoint to overwrite the CSV on disk
-app.post('/data/features.csv', (req, res) => {
-  const csvPath = path.join(__dirname, '..', 'data', 'features.csv');
-  fs.writeFile(csvPath, req.body, (err) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send('Failed to save CSV');
+// Load GitHub credentials from environment
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_OWNER = process.env.GITHUB_OWNER;
+const GITHUB_REPO = process.env.GITHUB_REPO;
+
+// Endpoint to commit the CSV to GitHub
+app.post('/save-features', async (req, res) => {
+  const content = req.body && req.body.content;
+  if (!content) {
+    return res.status(400).send('Missing content');
+  }
+  if (!GITHUB_TOKEN || !GITHUB_OWNER || !GITHUB_REPO) {
+    console.error('Missing GitHub configuration');
+    return res.status(500).send('Server misconfigured');
+  }
+  try {
+    // Fetch existing file to get its SHA
+    const getResp = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/data/features.csv`,
+      {
+        headers: {
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+          'User-Agent': 'map-app',
+        },
+      }
+    );
+    if (!getResp.ok) {
+      throw new Error('Failed to get existing file');
+    }
+    const getData = await getResp.json();
+
+    // Commit new content
+    const putResp = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/data/features.csv`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+          'User-Agent': 'map-app',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          message: 'Update features.csv',
+          content,
+          sha: getData.sha,
+        }),
+      }
+    );
+
+    if (!putResp.ok) {
+      const text = await putResp.text();
+      throw new Error(text);
     }
     res.sendStatus(200);
-  });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Failed to save CSV');
+  }
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add `/save-features` route that commits features.csv to GitHub using env credentials
- send base64 CSV from front-end to new route
- document new workflow and required environment variables

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4905c2ea8832eb939c80ae2e33ccf