### PR TITLE
Add image overlay upload with opacity control

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,9 @@
     <!-- <h1>map</h1> -->
     <div id="map"></div>
     <button id="save-changes">Save Changes</button>
-    <input type="file" id="overlay-upload" accept="image/*">
+    <input type="file" id="overlay-upload" accept="image/*" aria-label="Upload overlay image">
     <label for="overlay-opacity" id="overlay-opacity-label">Opacity:
-        <input type="range" id="overlay-opacity" min="0" max="1" step="0.1" value="1">
+        <input type="range" id="overlay-opacity" min="0" max="1" step="0.1" value="1" aria-label="Overlay opacity">
     </label>
     <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">

--- a/js/map.js
+++ b/js/map.js
@@ -27,6 +27,35 @@ map.on('mouseout', function () {
   mouseCoords.textContent = '';
 });
 
+var overlayLayer = null;
+document.getElementById('overlay-upload').addEventListener('change', function (e) {
+  var file = e.target.files[0];
+  if (!file) return;
+  var reader = new FileReader();
+  reader.onload = function (ev) {
+    if (overlayLayer) {
+      map.removeLayer(overlayLayer);
+    }
+    var bounds = map.getBounds();
+    overlayLayer = L.distortableImageOverlay(ev.target.result, {
+      corners: [
+        bounds.getNorthWest(),
+        bounds.getNorthEast(),
+        bounds.getSouthEast(),
+        bounds.getSouthWest(),
+      ],
+      opacity: parseFloat(document.getElementById('overlay-opacity').value),
+    }).addTo(map);
+  };
+  reader.readAsDataURL(file);
+});
+
+document.getElementById('overlay-opacity').addEventListener('input', function (e) {
+  if (overlayLayer) {
+    overlayLayer.setOpacity(parseFloat(e.target.value));
+  }
+});
+
 // Remove default marker shadows
 L.Icon.Default.mergeOptions({
   shadowUrl: null,


### PR DESCRIPTION
## Summary
- keep overlay controls accessible with ARIA labels
- allow uploading an image overlay and add it to the map
- adjust overlay opacity via slider in real time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5176ffeb8832e9641e778b982a43c