### PR TITLE
Enable dragging for uploaded overlay images

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -72,14 +72,16 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
         }).addTo(map);
         overlayScale = 1;
         if (overlaySizeSlider) overlaySizeSlider.value = 1;
-        if (overlayLayer.editing) {
-          overlayLayer.editing.enable();
-        }
-        if (overlayLayer.enableDragging) {
-          overlayLayer.enableDragging();
-        } else if (overlayLayer.dragging && overlayLayer.dragging.enable) {
-          overlayLayer.dragging.enable();
-        }
+        overlayLayer.once('load', function () {
+          if (overlayLayer.editing) {
+            overlayLayer.editing.enable();
+          }
+          if (overlayLayer.enableDragging) {
+            overlayLayer.enableDragging();
+          } else if (overlayLayer.dragging && overlayLayer.dragging.enable) {
+            overlayLayer.dragging.enable();
+          }
+        });
       };
       img.onerror = function () {
         var msg = 'The selected file is not a valid image.';


### PR DESCRIPTION
## Summary
- ensure uploaded overlay images become draggable once they finish loading

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c879f664832ea7c6bc60483fc10c