### PR TITLE
Fallback to local CSV download when saving text labels fails

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -630,7 +630,11 @@ function saveTextLabels() {
   updateEditToolbar();
   var csvContent = buildFeaturesCSV();
   sendFeaturesCsvToServer(csvContent).catch(function (err) {
-    console.error('Failed to save text labels', err);
+    console.error(
+      'Failed to save text labels to the server; downloading features.csv locally (offline mode).',
+      err
+    );
+    triggerCsvDownload(csvContent);
   });
 }
 


### PR DESCRIPTION
## Summary
- trigger a local download of features.csv when saving text labels cannot reach the server
- log the offline fallback to help surface the reason for the local download

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68c8ee351e68832e8125e4b31837e356