### PR TITLE
Enable footnotes in info panel descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This project is a web-based map using Leaflet. Users can add custom markers, text labels, and polygons.
 
+## Footnotes in Descriptions
+
+Descriptions for markers, text labels, and polygons support Markdown footnotes. Use the reference and definition pairings inside each description field, for example:
+
+```
+The site was documented in 1670.[^1]
+
+[^1]: Town archives, volume 3.
+```
+
+When editing `data/features.csv` directly, keep the footnote definitions inside the same cell as the references (typically add a blank line between the body and the list of definitions). The CSV exporter/importer preserves the `[^label]` reference and `[^label]: details` definition markup, so round-tripping through the UI keeps citations intact.
+
 ## Feature Export
 
 Click the **Save Changes** button to generate a CSV representation of all markers, text labels, and polygons. The client tries to POST the CSV to `/save-features` and, if the request succeeds (HTTP 200), the file is committed to the GitHub repository. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.

--- a/css/index.css
+++ b/css/index.css
@@ -40,9 +40,50 @@ html, body{
 }
 
 
-#info-title,
-#info-description {
+#info-title {
     text-align: center;
+}
+
+#info-description {
+    text-align: left;
+}
+
+#info-description .footnote-ref {
+    font-size: 0.75em;
+    line-height: 1;
+    vertical-align: super;
+}
+
+#info-description .footnote-ref a {
+    color: #555;
+    text-decoration: none;
+}
+
+#info-description .footnote-ref a:hover,
+#info-description .footnote-ref a:focus {
+    text-decoration: underline;
+}
+
+#info-description .footnotes {
+    margin-top: 0.75em;
+    padding-top: 0.5em;
+    border-top: 1px solid #ddd;
+    font-size: 0.85em;
+    text-align: left;
+}
+
+#info-description .footnotes ol {
+    margin: 0;
+    padding-left: 1.25em;
+}
+
+#info-description .footnotes li {
+    margin-bottom: 0.5em;
+}
+
+#info-description .footnotes a {
+    color: inherit;
+    text-decoration: underline;
 }
 
 #info-panel .close-button {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>
         <h2 id="info-title"></h2>
-        <p id="info-description"></p>
+        <div id="info-description"></div>
     </div>
     <div id="marker-form-overlay" class="hidden">
         <div id="marker-form">
@@ -30,7 +30,7 @@
                 <input type="text" id="marker-name">
             </label>
             <label>Description:
-                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images) and footnotes (pair <code>[^1]</code> with <code>[^1]: Source details</code>).</small>
                 <textarea id="marker-description"></textarea>
             </label>
             <label>Icon:
@@ -65,7 +65,7 @@
                 <input type="text" id="polygon-name">
             </label>
             <label>Description:
-                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images) and footnotes (pair <code>[^1]</code> with <code>[^1]: Source details</code>).</small>
                 <textarea id="polygon-description"></textarea>
             </label>
             <label>Color:
@@ -82,7 +82,7 @@
                 <input type="text" id="text-label-text">
             </label>
             <label>Description:
-                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images).</small>
+                <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images) and footnotes (pair <code>[^1]</code> with <code>[^1]: Source details</code>).</small>
                 <textarea id="text-label-description"></textarea>
             </label>
             <label>Size:


### PR DESCRIPTION
## Summary
- register a Marked extension that renders citation references and footnote blocks, and keep the required tags through DOMPurify
- style the rendered footnotes and update the UI helper copy to describe the supported syntax
- document how to author footnotes in `data/features.csv` so round-tripping the CSV preserves the markup

## Testing
- node - <<'NODE' <small script verifying CSV round trip>


------
https://chatgpt.com/codex/tasks/task_e_68ce3a7740d0832e80636fbad425d544