### PR TITLE
Keep text labels anchored while zooming

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -116,7 +116,7 @@ html, body{
 /* Style for text markers */
 .text-label {
     position: absolute;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, 0);
     text-align: center;
 }
 .text-label span {
@@ -125,9 +125,11 @@ html, body{
     color: #333;
     display: inline-block;
     letter-spacing: 0;
+    transform-origin: top center;
 }
 .text-label svg {
     overflow: visible;
+    transform-origin: top center;
 }
 
 /* Marker form styles */


### PR DESCRIPTION
## Summary
- adjust the text label positioning so zoom scaling keeps the top of the label fixed to the marker
- update text label transform origins so rotations still pivot around the anchored top edge

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d2385c76b8832e9129e2655b6c4db4