### PR TITLE
Add Quinnitekuk map legend text markers

### DIFF
--- a/data/features.csv
+++ b/data/features.csv
@@ -508,6 +508,66 @@ text,41.541477666790286,-99.86572265625,,,Moonkeek-Shoonkeek,,6,0,0,0,,,Bodies o
 text,38.42777351132902,-100.50292968750001,,,Pontoosuck,,6,0,0,0,,,Bodies of Water
 text,49.993615462541136,-65.17089843750001,,,Paugemtuk,,5,0,0,0,,,Rivers
 text,44.15068115978094,-47.4169921875,,,Quinnitekuk,,5,0,0,0,,,Rivers
+text,45.300000000000004,-47.20000000000001,,,Mattamacket,,5,0,0,0,,,Bodies of Water
+text,44.15068115978094,-45.900000000000006,,,Taughkannacoas Islands,,5,0,0,0,,,Bodies of Water
+text,43.10000000000001,-47.20000000000001,,,Alliancook,,5,0,0,0,,,Bodies of Water
+text,44.69068115978094,-47.1369921875,,,Skakeat Squakheag,,5,0,0,0,,,Geographical Locations
+text,44.49068115978094,-48.0719921875,,,Nallaharcomgon,,5,0,0,0,,,Geographical Locations
+text,44.050681159780936,-48.6519921875,,,Puckommegon,,5,0,0,0,,,Geographical Locations
+text,43.730681159780936,-49.3269921875,,,Paugen,,5,0,0,0,,,Geographical Locations
+text,43.53068115978094,-48.3319921875,,,Suns Skowohkk,,5,0,0,0,,,Geographical Locations
+text,43.19068115978094,-48.2594921875,,,Saci Mi (Papacontuckquash),,5,0,0,0,,,Geographical Locations
+text,43.060681159780934,-46.2169921875,,,Papacontuckquash,,5,0,0,0,,,Geographical Locations
+text,42.82068115978094,-47.5819921875,,,Sa Inpskeshoa,,5,0,0,0,,,Geographical Locations
+text,42.22068115978094,-48.5269921875,,,Neqwomt,,5,0,0,0,,,Geographical Locations
+text,42.03068115978094,-49.0819921875,,,Weekquunnuch,,5,0,0,0,,,Geographical Locations
+text,41.81068115978094,-48.6269921875,,,Amiskw Alow,,5,0,0,0,,,Geographical Locations
+text,41.81068115978094,-47.9619921875,,,Kia,,5,0,0,0,,,Geographical Locations
+text,41.71068115978094,-46.4869921875,,,Pottapaug,,5,0,0,0,,,Geographical Locations
+text,41.60068115978094,-47.8719921875,,,Bivahs,,5,0,0,0,,,Geographical Locations
+text,41.51068115978094,-47.5169921875,,,Siok,,5,0,0,0,,,Geographical Locations
+text,41.26068115978094,-48.6069921875,,,Mattawan,,5,0,0,0,,,Geographical Locations
+text,41.050681159780936,-49.0719921875,,,Mins,,5,0,0,0,,,Geographical Locations
+text,41.050681159780936,-48.4369921875,,,Barhar,,5,0,0,0,,,Geographical Locations
+text,40.97068115978094,-47.0619921875,,,Nea,,5,0,0,0,,,Geographical Locations
+text,40.870681159780936,-47.7719921875,,,Omanacig,,5,0,0,0,,,Geographical Locations
+text,40.82068115978094,-48.6169921875,,,Weauitayaug,,5,0,0,0,,,Geographical Locations
+text,40.730681159780936,-46.4419921875,,,Temes,,5,0,0,0,,,Geographical Locations
+text,40.57068115978094,-48.6169921875,,,Kapawank,,5,0,0,0,,,Geographical Locations
+text,40.51068115978094,-47.8869921875,,,Seca Naot,,5,0,0,0,,,Geographical Locations
+text,40.17068115978094,-46.5569921875,,,Menemesty,,5,0,0,0,,,Geographical Locations
+text,40.10068115978094,-48.7119921875,,,Pacha,,5,0,0,0,,,Geographical Locations
+text,40.03068115978094,-49.6469921875,,,Akikons,,5,0,0,0,,,Geographical Locations
+text,39.910681159780935,-48.8219921875,,,Asotalak,,5,0,0,0,,,Geographical Locations
+text,39.740681159780934,-47.9369921875,,,Poa,,5,0,0,0,,,Geographical Locations
+text,39.71068115978094,-48.6919921875,,,Nerwotuk,,5,0,0,0,,,Geographical Locations
+text,39.450681159780935,-48.6369921875,,,Kuna,,5,0,0,0,,,Geographical Locations
+text,39.26068115978094,-47.9419921875,,,Wanmagoekset,,5,0,0,0,,,Geographical Locations
+text,39.01068115978094,-48.0119921875,,,Chusick,,5,0,0,0,,,Geographical Locations
+text,38.82068115978094,-46.1469921875,,,Serhan,,5,0,0,0,,,Geographical Locations
+text,38.620681159780936,-45.7869921875,,,Letone,,5,0,0,0,,,Geographical Locations
+text,38.31068115978094,-49.5369921875,,,Woninohe / Wol,,5,0,0,0,,,Geographical Locations
+text,38.270681159780935,-47.9719921875,,,Ricoh,,5,0,0,0,,,Geographical Locations
+text,38.130681159780934,-46.5519921875,,,Ashquash,,5,0,0,0,,,Geographical Locations
+text,37.75068115978094,-48.1469921875,,,Nyaset,,5,0,0,0,,,Geographical Locations
+text,37.57068115978094,-49.2269921875,,,Pochasuch,,5,0,0,0,,,Geographical Locations
+text,37.51068115978094,-48.0869921875,,,Aalok,,5,0,0,0,,,Geographical Locations
+text,37.43068115978094,-46.8869921875,,,Quasiak,,5,0,0,0,,,Geographical Locations
+text,37.43068115978094,-46.2869921875,,,Tantasgues,,5,0,0,0,,,Geographical Locations
+text,37.19068115978094,-48.0169921875,,,Massa,,5,0,0,0,,,Geographical Locations
+text,36.990681159780934,-46.7619921875,,,Matewemesik,,5,0,0,0,,,Geographical Locations
+text,36.97068115978094,-48.4969921875,,,Asan,,5,0,0,0,,,Geographical Locations
+text,36.83068115978094,-47.9219921875,,,Muskikoshitash,,5,0,0,0,,,Geographical Locations
+text,36.57068115978094,-48.0669921875,,,Suckompsk,,5,0,0,0,,,Geographical Locations
+text,36.53068115978094,-46.5219921875,,,Mashapaus,,5,0,0,0,,,Geographical Locations
+text,36.450681159780935,-45.5719921875,,,Quinnebaue,,5,0,0,0,,,Geographical Locations
+text,36.33068115978094,-48.0569921875,,,Suis,,5,0,0,0,,,Geographical Locations
+text,36.21068115978094,-47.4169921875,,,Poggotussue,,5,0,0,0,,,Geographical Locations
+text,35.800681159780936,-47.5869921875,,,Amiskwatamal,,5,0,0,0,,,Geographical Locations
+text,35.660681159780935,-49.2269921875,,,Wenckocamaug,,5,0,0,0,,,Geographical Locations
+text,35.410681159780935,-49.5469921875,,,Massaco,,5,0,0,0,,,Geographical Locations
+text,35.15068115978094,-47.4869921875,,,Nashaway, Quaboag and Quinnebaug Nipmuk: Pocumtuk, Podunk, Norwotuk, Woronok, Massaco,,5,0,0,0,,,Geographical Locations
+text,34.910681159780935,-47.4869921875,,,Mashapaug and Sokoki Wobankai Nations Territories,,5,0,0,0,,,Geographical Locations
 text,47.78363463526379,-35.20019531250001,,,Papacontuckquash,,5,0,0,0,,,Rivers
 text,-20.694461597907797,43.57177734375001,,,Pawtucket,,7,0,0,0,,,Settlements
 text,-22.695120184965695,44.36279296875,,,Seacuncke,,7,0,0,0,,,Settlements


### PR DESCRIPTION
## Summary
- add size-5 text markers for the Quinnitekuk map legend, including Skakeat Squakheag, Nallaharcomgon, and related names around the river
- capture associated place names and legend text such as Saci Mi (Papacontuckquash), Nashaway and Sokoki Wobankai territories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ac8e3e9c832e955af57074132928