### PR TITLE
Show marker icons in top-right label menu

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -202,6 +202,18 @@ html, body{
     display: none;
 }
 
+.overlay-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.overlay-label__icon {
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
+}
+
 /* Glow effect for markers */
 .leaflet-marker-icon:hover,
 .marker-selected {

--- a/js/map.js
+++ b/js/map.js
@@ -894,6 +894,39 @@ var overlays = {
   Territories: territoriesOverlay,
 };
 
+var overlayLegendIcons = {
+  Settlements: 'settlement',
+  'Planting Grounds': 'agriculture',
+  'Fishing Weirs': 'fishing',
+  'Mines/Quarries': 'mine',
+  Petroglyph: 'pteroglyph',
+  Forts: 'forts',
+};
+
+function getOverlayLabelMarkup(name) {
+  var iconKey = overlayLegendIcons[name];
+  if (!iconKey || !iconMap[iconKey] || !iconMap[iconKey].options) {
+    return name;
+  }
+  var iconOptions = iconMap[iconKey].options;
+  var iconUrl = iconOptions.iconUrl || '';
+  var iconSize = iconOptions.iconSize || [16, 16];
+  var width = iconSize[0] || 16;
+  var height = iconSize[1] || 16;
+  return (
+    '<span class="overlay-label">' +
+      '<img class="overlay-label__icon" src="' +
+      iconUrl +
+      '" alt="" width="' +
+      width +
+      '" height="' +
+      height +
+      '">' +
+      '<span>' + name + '</span>' +
+    '</span>'
+  );
+}
+
 var additionalOverlayNames = [
   'Ceremonial Stone Landscapes',
   'Mountains',
@@ -936,7 +969,11 @@ function populateOverlaySelects() {
 }
 
 populateOverlaySelects();
-L.control.layers(null, overlays).addTo(map);
+var layerControlOverlays = {};
+Object.keys(overlays).forEach(function (name) {
+  layerControlOverlays[getOverlayLabelMarkup(name)] = overlays[name];
+});
+L.control.layers(null, layerControlOverlays).addTo(map);
 
 function clearSelectedMarker() {
   if (selectedMarker && selectedMarker._icon) {


### PR DESCRIPTION
### Motivation
- Improve the Leaflet layer control in the top-right label menu by showing the marker icon associated with certain overlay categories so users can see the marker preview next to the overlay name.
- Provide a consistent, compact visual cue for mapped overlay categories such as Settlements, Planting Grounds, Fishing Weirs, Mines/Quarries, Petroglyph, and Forts.

### Description
- Add an `overlayLegendIcons` mapping and `getOverlayLabelMarkup(name)` that returns HTML combining an `<img>` preview with the overlay name when a matching icon exists in `iconMap` (file: `js/map.js`).
- Initialize the Leaflet layers control using HTML labels built by `getOverlayLabelMarkup` so entries render with icon+text while preserving layer functionality (file: `js/map.js`).
- Add CSS classes `.overlay-label` and `.overlay-label__icon` to align and size the icon preview used in the layer control (file: `css/index.css`).

### Testing
- Run `node --check js/map.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3da84d4832e90ceacd9a66a2ecd)