### PR TITLE
Fix CSV download object URL cleanup in map export flow

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1465,11 +1465,13 @@ function sendFeaturesCsvToServer(csvContent) {
 function triggerCsvDownload(csvContent) {
   var blob = new Blob([csvContent], { type: 'text/csv' });
   var a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
+  var objectUrl = URL.createObjectURL(blob);
+  a.href = objectUrl;
   a.download = 'features.csv';
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
+  URL.revokeObjectURL(objectUrl);
 }
 
 function exportFeaturesToCSV() {
@@ -1485,8 +1487,6 @@ function saveMarkers() {
 
 function saveTextLabels() {
   updateEditToolbar();
-  var csvContent = buildFeaturesCSV();
-  
 }
 
 function savePolygons() {


### PR DESCRIPTION
### Motivation
- Prevent accumulation of unreleased Blob object URLs during CSV fallback downloads and remove a small piece of dead code in the text-label save flow.

### Description
- Change `triggerCsvDownload` to store the `Blob` object URL in a variable and call `URL.revokeObjectURL(objectUrl)` after triggering the download to free resources.
- Remove an unused `csvContent = buildFeaturesCSV()` assignment from `saveTextLabels()` to avoid dead code.

### Testing
- Ran static checks `node --check js/map.js` and `node --check server/index.js`, both commands completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4525709a4832e8ef1dedda081fedf)