### PR TITLE
Prevent footnote links from overflowing info panel

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -183,9 +183,12 @@ html, body{
     margin-bottom: 0.5em;
 }
 
+
 #info-description .footnotes a {
     color: inherit;
     text-decoration: underline;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 #info-panel .close-button {


### PR DESCRIPTION
### Motivation
- Long citation URLs in the info panel's footnotes were extending past the panel edge, causing links to go off the right side of the container; this change fixes that layout bug.

### Description
- Add `overflow-wrap: anywhere;` and `word-break: break-word;` to the `#info-description .footnotes a` rule in `css/index.css` to allow long links to wrap inside the panel.
- No additional skills or external tools were required to make this small CSS change.

### Testing
- Ran `git diff -- css/index.css` to verify the CSS diff includes the new wrapping rules and it succeeded.
- Inspected the updated file with `nl -ba css/index.css | sed -n '178,200p'` to confirm the inserted lines are present and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f455e1ba58832e892e0fb22674470f)